### PR TITLE
Fix the broken onboarder helpcenter logo on the articles

### DIFF
--- a/src/partials/navbar-with-search.handlebars
+++ b/src/partials/navbar-with-search.handlebars
@@ -2,7 +2,7 @@
     <div class="container-fluid">
         <div class="navbar-header">
             <a class="navbar-brand" href="/">
-                <img height="20" src="/img/akeneo.svg"></img>
+                <img height="20" src="/img/onboarder.svg"></img>
             </a>
         </div>
         <div class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Changing the image file used on src/partials/navbar-with-search.handlebars from akeneo.svg to onboarder.svg.