### PR TITLE
Tag "onboarder" for algolia's search

### DIFF
--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -54,12 +54,15 @@
 </body>
 <script type="text/javascript">
     if($('#docSearch-input').length){
-        docsearch({
-            apiKey: '383063c398d4eb9df08945560d3d26fc',
-            indexName: 'akeneo-help',
-            inputSelector: '#docSearch-input',
-            debug: false // Set debug to true if you want to inspect the dropdown
-        });
+      docsearch({
+          apiKey: '383063c398d4eb9df08945560d3d26fc',
+          indexName: 'akeneo-help',
+          inputSelector: '#docSearch-input',
+          debug: false, // Set debug to true if you want to inspect the dropdown
+          algoliaOptions: {
+            'facetFilters': ["tags:onboarder"]
+          }
+      });
     }
 </script>
 <script>


### PR DESCRIPTION
Add the "onboarder tag" on algolia's search bar to filter the results.