### PR TITLE
Fix link

### DIFF
--- a/src/indexes/index.handlebars
+++ b/src/indexes/index.handlebars
@@ -3,7 +3,7 @@
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container-fluid">
         <div class="navbar-header">
-            <a class="navbar-brand" href="/onboarder">
+            <a class="navbar-brand" href="/">
                 <img height="20" src="/onboarder/img/akeneo.svg"></img>
             </a>
         </div>


### PR DESCRIPTION
The Akeneo logo help center should link back to the home page of the help centers, not the Onboarder help center homepage.