### PR TITLE
Upgrade ubuntu image to 20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
     build:
         machine:
-            image: ubuntu-1604:202004-01
+            image: ubuntu-2004:202201-02
         steps:
             - checkout
             -   run: make build
 
     deploy_staging:
         machine:
-            image: ubuntu-1604:202004-01
+            image: ubuntu-2004:202201-02
         steps:
             - checkout
             - add_ssh_keys
@@ -19,7 +19,7 @@ jobs:
 
     deploy_production:
         machine:
-            image: ubuntu-1604:202004-01
+            image: ubuntu-2004:202201-02
         steps:
             - checkout
             - add_ssh_keys


### PR DESCRIPTION
CircleCI are deprecating Ubuntu 16.04-based machine images on CircleCI in preparation for an EOL on Tuesday, May 31, 2022 to ensure your builds remain secure.